### PR TITLE
토큰 쿠키 저장 처리로 변경 및 캐싱 처리 개선

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -7,7 +7,8 @@ import { motion, AnimatePresence } from "framer-motion";
 import Modal from "../../components/Modal";
 import AlertModal from "@/components/AlertModal";
 import useAlertModal from "@/hooks/useAlertModal";
-import axios from "axios";
+import { AxiosError } from "axios";
+import Cookies from "js-cookie";
 
 interface Store {
   storeId: string;
@@ -21,89 +22,101 @@ interface OperatingTime {
 
 export default function HomePage() {
   const router = useRouter();
-
-  const [showModal, setShowModal] = useState(false);
   const [stores, setStores] = useState<Store[]>([]);
   const [selectedStore, setSelectedStore] = useState<Store | null>(null);
+  const [showModal, setShowModal] = useState(false);
   const [showStoreModal, setShowStoreModal] = useState(false);
+  const [showStartModal, setShowStartModal] = useState(false);
   const [enteredPassword, setEnteredPassword] = useState("");
   const [loginError, setLoginError] = useState("");
-  const [showStartModal, setShowStartModal] = useState(false);
-
-  // useAlertModal 훅 사용
   const { alertState, showAlert, closeAlert } = useAlertModal();
 
-  useEffect(() => {
-    const checkAndRefreshToken = async () => {
-      const accessToken = localStorage.getItem("accessToken");
-      const refreshToken = localStorage.getItem("refreshToken");
+  const refetchStores = async () => {
+    try {
+      const response = await axiosInstance.get("/api/stores");
+      if (Array.isArray(response.data)) {
+        setStores(response.data);
+      } else {
+        throw new Error("Invalid stores data format");
+      }
+    } catch (error) {
+      if ((error as AxiosError)?.response?.status === 401) {
+        await handleTokenRefresh();
+      } else {
+        showAlert("스토어 정보를 가져오는데 실패했습니다.", "error");
+      }
+    }
+  };
 
-      if (!accessToken && refreshToken) {
-        try {
-          const response = await axiosInstance.post("/auth/refresh", {
-            refreshToken,
+  const handleTokenRefresh = async () => {
+    const refreshToken = Cookies.get("refreshToken");
+    if (!refreshToken) {
+      showAlert("세션이 만료되었습니다. 다시 로그인해주세요.", "warning");
+      handleLogout();
+      return;
+    }
+
+    try {
+      const response = await axiosInstance.post("/auth/refresh", { refreshToken });
+      if (response.data.access_token) {
+        Cookies.set("accessToken", response.data.access_token, {
+          expires: 1 / 24, // 1시간
+          secure: true,
+          sameSite: "Strict",
+        });
+        if (response.data.refresh_token) {
+          Cookies.set("refreshToken", response.data.refresh_token, {
+            expires: 7, // 7일
+            secure: true,
+            sameSite: "Strict",
           });
-          localStorage.setItem("accessToken", response.data.accessToken);
-          localStorage.setItem("refreshToken", response.data.refreshToken);
-          refetchStores();
-        } catch (error) {
-          console.error("Token refresh failed:", error);
-          handleLogout();
         }
-      } else if (!accessToken && !refreshToken) {
+        await refetchStores();
+      } else {
+        throw new Error("No access_token in refresh response");
+      }
+    } catch (error) {
+      showAlert("세션이 만료되었습니다. 다시 로그인해주세요.", "warning");
+      handleLogout();
+    }
+  };
+
+  useEffect(() => {
+    const initialize = async () => {
+      const accessToken = Cookies.get("accessToken");
+      const refreshToken = Cookies.get("refreshToken");
+
+      if (!accessToken && !refreshToken) {
         showAlert("세션이 만료되었습니다. 다시 로그인해주세요.", "warning");
         handleLogout();
+      } else if (!accessToken && refreshToken) {
+        await handleTokenRefresh();
+      } else {
+        await refetchStores();
       }
     };
-    checkAndRefreshToken();
-  }, []);
-
-  useEffect(() => {
-    const fetchStores = async () => {
-      const accessToken = localStorage.getItem("accessToken");
-      if (accessToken) {
-        try {
-          const response = await axiosInstance.get("/api/stores");
-          setStores(response.data);
-        } catch (error) {
-          console.error("Error fetching stores: ", error);
-        }
-      }
-    };
-    fetchStores();
+    initialize();
   }, []);
 
   const handleLogout = async () => {
     try {
       await axiosInstance.post("/auth/logout");
     } catch (error) {
-      console.error("Logout error: ", error);
+      // 로그아웃 실패 시에도 진행
     } finally {
-      localStorage.clear();
-      // 쿠키 삭제
-      document.cookie =
-        "auth_token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+      Cookies.remove("accessToken");
+      Cookies.remove("refreshToken");
+      Cookies.remove("currentStoreId");
       router.push("/");
     }
   };
 
-  const handleGoCreate = () => {
-    router.push("/create");
-  };
-
-  const refetchStores = async () => {
-    try {
-      const response = await axiosInstance.get("/api/stores");
-      setStores(response.data);
-    } catch (error) {
-      console.error("Error refetching stores: ", error);
-    }
-  };
+  const handleGoCreate = () => router.push("/create");
 
   const handleStoreButtonClick = (store: Store) => {
+    setSelectedStore(store);
     setEnteredPassword("");
     setLoginError("");
-    setSelectedStore(store);
     setShowStoreModal(true);
   };
 
@@ -112,7 +125,6 @@ export default function HomePage() {
       setLoginError("");
       setEnteredPassword("");
     }
-
     if (enteredPassword.length < 4) {
       setEnteredPassword((prev) => prev + num);
     }
@@ -123,11 +135,6 @@ export default function HomePage() {
     setLoginError("");
   };
 
-  const handleCloseAlreadyOpenModal = () => {
-    closeAlert();
-    router.push("/pos"); // /pos로 이동
-  };
-
   const handleConfirmClick = async () => {
     if (!enteredPassword || !selectedStore) return;
 
@@ -136,55 +143,35 @@ export default function HomePage() {
         storeId: selectedStore.storeId,
         password: enteredPassword,
       });
-      console.log("Login response:", response.data);
-
       const { storeId } = response.data;
-      if (!storeId) {
-        throw new Error("스토어 정보가 응답에 포함되지 않았습니다.");
-      }
+      if (!storeId) throw new Error("스토어 정보가 응답에 포함되지 않았습니다.");
 
-      localStorage.setItem("currentStoreId", storeId.toString());
-
-      console.log("Store ID saved:", {
-        storeId: localStorage.getItem("currentStoreId"),
-        accessToken: localStorage.getItem("accessToken"),
-        refreshToken: localStorage.getItem("refreshToken"),
+      Cookies.set("currentStoreId", storeId.toString(), {
+        expires: 1, // 1일
+        secure: true,
+        sameSite: "Strict",
       });
 
-      // 운영 시간 데이터 가져오기
-      const operatingTimesResponse = await axiosInstance.get(
-        "/api/times/all-info"
-      );
+      const operatingTimesResponse = await axiosInstance.get("/api/times/all-info");
       const operatingTimes = operatingTimesResponse.data;
 
-      console.log("Operating Times:", operatingTimes); // 디버깅 로그
-
-      // 운영 시간 확인 - 단순화된 로직으로 변경
-      const isStoreAlreadyOpen = operatingTimes.some((time: OperatingTime) => {
-        return (
-          time.storeId.toString() === storeId.toString() &&
-          time.closedAt === null
-        );
-      });
-
-      console.log("Is Store Already Open:", isStoreAlreadyOpen); // 디버깅 로그
+      const isStoreAlreadyOpen = operatingTimes.some(
+        (time: OperatingTime) =>
+          time.storeId.toString() === storeId.toString() && time.closedAt === null
+      );
 
       setShowStoreModal(false);
       if (isStoreAlreadyOpen) {
-        // AlertModal 사용
         showAlert("이미 오픈 되어있는 매장이 있습니다.", "warning", false);
-
-        // 2초 후 자동으로 POS 페이지로 이동
         setTimeout(() => {
           closeAlert();
           router.push("/pos");
         }, 3000);
       } else {
-        setShowStartModal(true); // 오픈되지 않은 경우 시작 모달 표시
+        setShowStartModal(true);
       }
-    } catch (error: any) {
-      console.error("로그인 요청 중 오류 발생:", error);
-      if (error.response?.status === 401) {
+    } catch (error) {
+      if ((error as AxiosError)?.response?.status === 401) {
         setLoginError("비밀번호가 틀렸습니다.");
         setEnteredPassword("");
       }
@@ -195,11 +182,9 @@ export default function HomePage() {
     if (!selectedStore) return;
     try {
       await axiosInstance.post(`/api/times/open/${selectedStore.storeId}`);
-      console.log("Store opened successfully");
       setShowStartModal(false);
       router.push("/pos");
     } catch (error) {
-      console.error("Error opening store:", error);
       showAlert("매장 오픈 중 오류가 발생했습니다.", "error");
     }
   };
@@ -208,11 +193,7 @@ export default function HomePage() {
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-gray-100 relative">
-      <div
-        className={`grid ${
-          stores.length <= 1 ? "grid-cols-1" : "grid-cols-3"
-        } gap-4`}
-      >
+      <div className={`grid ${stores.length <= 1 ? "grid-cols-1" : "grid-cols-3"} gap-4`}>
         {stores.map((store) => (
           <button
             key={store.storeId}
@@ -234,11 +215,7 @@ export default function HomePage() {
             stroke="currentColor"
             strokeWidth={2}
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M12 4v16m8-8H4"
-            />
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
           </svg>
         </button>
       </div>
@@ -249,8 +226,9 @@ export default function HomePage() {
       >
         Logout
       </button>
+
       <Modal isOpen={showModal} onClose={() => setShowModal(false)}>
-        <div className="relative z-10 flex flex-col items-center justify-center h-full text-[#555]">
+        <div className="flex flex-col items-center justify-center h-full text-[#555]">
           <h1 className="text-md">로그아웃 하시겠습니까?</h1>
           <div className="flex space-x-4 mt-6">
             <button
@@ -303,39 +281,23 @@ export default function HomePage() {
               </div>
 
               <div className="grid grid-cols-3 gap-2">
-                {[
-                  "1",
-                  "2",
-                  "3",
-                  "4",
-                  "5",
-                  "6",
-                  "7",
-                  "8",
-                  "9",
-                  "Del",
-                  "0",
-                  "✓",
-                ].map((key, index) => {
-                  const handleClick = () => {
-                    if (key === "Del") {
-                      handleClearClick();
-                    } else if (key === "✓") {
-                      handleConfirmClick();
-                    } else {
-                      handleNumberClick(key);
-                    }
-                  };
-                  return (
+                {["1", "2", "3", "4", "5", "6", "7", "8", "9", "Del", "0", "✓"].map(
+                  (key, index) => (
                     <button
                       key={index}
-                      onClick={handleClick}
+                      onClick={() =>
+                        key === "Del"
+                          ? handleClearClick()
+                          : key === "✓"
+                          ? handleConfirmClick()
+                          : handleNumberClick(key)
+                      }
                       className="flex items-center justify-center h-12 bg-[#f5f5f5] rounded hover:bg-gray-200 transition"
                     >
                       {key}
                     </button>
-                  );
-                })}
+                  )
+                )}
               </div>
 
               <div className="h-[45px] mt-2 flex items-center justify-center mb-2">
@@ -376,7 +338,6 @@ export default function HomePage() {
         </div>
       </Modal>
 
-      {/* AlertModal 사용 */}
       <AlertModal
         isOpen={alertState.isOpen}
         onClose={closeAlert}

--- a/app/payment/page.tsx
+++ b/app/payment/page.tsx
@@ -308,11 +308,13 @@ export default function PaymentPage() {
   const handleReceiptYes = async () => {
     if (orderId) {
       try {
-        const receiptResponse = await axiosInstance.get(
-          `/api/receipts/${orderId}`
-        );
+        const receiptResponse = await axiosInstance.get(`/api/receipts/${orderId}`);
         console.log("영수증 데이터:", receiptResponse.data);
+  
+        // 결제 관련 상태만 초기화
         resetData();
+  
+        // storeId가 유지되므로 바로 /pos로 이동
         router.push("/pos");
       } catch (error: any) {
         console.error("영수증 가져오기 실패:", error.response?.data || error);

--- a/app/pos/page.tsx
+++ b/app/pos/page.tsx
@@ -7,6 +7,7 @@ import CategoryButton from "../../components/CategoryButton";
 import MenuButton from "../../components/PosMenuButton";
 import SelectedMenuList from "../../components/SelectedMenuList";
 import PlaceModal from "../../components/PlaceModal";
+import Cookies from "js-cookie";
 
 interface SelectedItem {
   menuName: string;
@@ -43,37 +44,31 @@ export default function PosPage() {
 
   // storeId 초기화 및 데이터 로드
   useEffect(() => {
-    const savedStoreId = localStorage.getItem("currentStoreId");
+    const savedStoreId = Cookies.get("currentStoreId");
     const newStoreId = savedStoreId ? Number(savedStoreId) : null;
 
     if (newStoreId) {
-      console.log("Initializing or restoring storeId:", newStoreId);
       if (newStoreId !== storeId) {
         setStoreId(newStoreId);
       }
-
-      // 항상 카테고리와 메뉴를 로드
       fetchCategories(newStoreId).then(() => {
         const state = usePosStore.getState();
-        console.log("Categories loaded:", state.categories);
         const firstCategoryId = state.categories[0]?.categoryId;
         if (firstCategoryId && firstCategoryId !== selectedCategoryId) {
-          console.log("Setting selectedCategoryId to:", firstCategoryId);
           setSelectedCategoryId(firstCategoryId);
         }
       });
     }
-  }, [setStoreId, fetchCategories]); // 의존성에서 storeId 제거
+  }, [setStoreId, fetchCategories]);
 
   // selectedCategoryId 변경 시 메뉴 로드
   useEffect(() => {
     if (selectedCategoryId && storeId) {
-      console.log("Fetching menus for storeId:", storeId, "categoryId:", selectedCategoryId);
-      fetchMenusByCategory(selectedCategoryId, true);
+      fetchMenusByCategory(selectedCategoryId, true); // 항상 새 데이터 로드
     }
   }, [selectedCategoryId, storeId, fetchMenusByCategory]);
 
-  // 디버깅 로그
+  // 디버깅 로그 추가
   useEffect(() => {
     console.log("PosPage - storeId:", storeId);
     console.log("PosPage - categories:", categories);

--- a/app/setting/page.tsx
+++ b/app/setting/page.tsx
@@ -13,6 +13,7 @@ import axiosInstance from "../../lib/axiosInstance";
 import { useFormStore } from "@/store/formStore";
 import { usePosStore } from "@/store/usePosStore";
 import Modal from "@/components/Modal";
+import Cookies from "js-cookie";
 
 export default function SettingPage() {
   const router = useRouter();
@@ -29,8 +30,8 @@ export default function SettingPage() {
 
   useEffect(() => {
     if (typeof window !== "undefined") {
-      const token = localStorage.getItem("accessToken");
-      const currentStoreId = localStorage.getItem("currentStoreId");
+      const token = Cookies.get("accessToken");
+      const currentStoreId = Cookies.get("currentStoreId");
 
       if (!token || !currentStoreId) {
         alert("세션이 만료되었습니다. 다시 로그인해주세요.");
@@ -56,12 +57,11 @@ export default function SettingPage() {
         setShowIncompleteOrderModal(true);
         setShowCloseModal(false);
       } else {
-        console.log("Store closed successfully");
         setShowCloseModal(false);
         router.push("/home");
       }
     } catch (error) {
-      console.error("Error closing store:", error);
+      // 오류 처리 생략 (UI에 표시되지 않음)
     }
   };
 
@@ -75,12 +75,12 @@ export default function SettingPage() {
   };
 
   const handleOrdersClick = () => {
-    router.push("setting/orders");
+    router.push("/setting/orders");
   };
 
   const handleTransferClick = () => {
-    resetData(); // 모든 상태(캐시 포함) 초기화
-    localStorage.removeItem("currentStoreId"); // 현재 storeId 제거
+    resetData();
+    Cookies.remove("currentStoreId");
     router.push("/home");
   };
 

--- a/app/setting/page.tsx
+++ b/app/setting/page.tsx
@@ -3,9 +3,7 @@ import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   ShoppingBag,
-  Settings,
   ChevronLeft,
-  SquareChartGantt,
   Archive,
   PanelRightClose,
   ArrowRightLeft,
@@ -13,27 +11,20 @@ import {
 import { motion, AnimatePresence } from "framer-motion";
 import axiosInstance from "../../lib/axiosInstance";
 import { useFormStore } from "@/store/formStore";
+import { usePosStore } from "@/store/usePosStore";
 import Modal from "@/components/Modal";
 
 export default function SettingPage() {
   const router = useRouter();
   const { storeId, setStoreId } = useFormStore();
+  const { resetData } = usePosStore();
 
-  // 메인 UI (Heading + 6개 버튼) 표시 여부
   const [showMainUI, setShowMainUI] = useState(true);
-  // 메인 UI 페이드아웃 트리거
   const [fadeOutMainUI, setFadeOutMainUI] = useState(false);
-
-  // Edit UI (Edit Items / Edit Categories 버튼) 표시 여부
   const [showEditUI, setShowEditUI] = useState(false);
-  // Edit UI 페이드아웃 트리거
   const [fadeOutEditUI, setFadeOutEditUI] = useState(false);
-  // 영업 마감 상태
   const [showCloseModal, setShowCloseModal] = useState(false);
-  // 미완료 주문 알림 모달 상태
-  const [showIncompleteOrderModal, setShowIncompleteOrderModal] =
-    useState(false);
-  // 미완료 주문 메시지
+  const [showIncompleteOrderModal, setShowIncompleteOrderModal] = useState(false);
   const [incompleteOrderMessage, setIncompleteOrderMessage] = useState("");
 
   useEffect(() => {
@@ -45,7 +36,6 @@ export default function SettingPage() {
         alert("세션이 만료되었습니다. 다시 로그인해주세요.");
         router.push("/");
       } else {
-        // 문자로 저장되어 있으므로 number 변환
         setStoreId(Number(currentStoreId));
       }
     }
@@ -59,22 +49,13 @@ export default function SettingPage() {
     if (!storeId) return;
     try {
       const response = await axiosInstance.post(`/api/times/close/${storeId}`);
-      console.log("response for close: ", response);
-
-      // 응답에 message가 있는지 확인 (미완료 주문이 있는 경우)
       if (
-        response.data &&
-        response.data.message &&
-        response.data.message.includes("아직 완료되지 않은 주문이 존재합니다")
+        response.data?.message?.includes("아직 완료되지 않은 주문이 존재합니다")
       ) {
-        // 미완료 주문 메시지 설정 및 모달 표시
         setIncompleteOrderMessage(response.data.message);
         setShowIncompleteOrderModal(true);
         setShowCloseModal(false);
-
-        // 이 경우 홈으로 이동하지 않음
       } else {
-        // 정상적으로 마감된 경우
         console.log("Store closed successfully");
         setShowCloseModal(false);
         router.push("/home");
@@ -84,17 +65,11 @@ export default function SettingPage() {
     }
   };
 
-  /**
-   * Items 버튼 클릭 => 메인 UI를 페이드아웃 -> 제거 -> Edit UI를 페이드인
-   */
   const handleItemsClick = () => {
-    // 1) 메인 UI 페이드아웃 시작
     setFadeOutMainUI(true);
-
-    // 2) 애니메이션(0.4s) 후 메인 UI 제거 + Edit UI 표시
     setTimeout(() => {
       setShowMainUI(false);
-      setFadeOutMainUI(false); // 초기화
+      setFadeOutMainUI(false);
       setShowEditUI(true);
     }, 400);
   };
@@ -104,27 +79,20 @@ export default function SettingPage() {
   };
 
   const handleTransferClick = () => {
+    resetData(); // 모든 상태(캐시 포함) 초기화
+    localStorage.removeItem("currentStoreId"); // 현재 storeId 제거
     router.push("/home");
   };
 
-  /**
-   * 뒤로가기(상단 화살표) 클릭 시 동작
-   * - 메인 UI가 숨겨져 있으면 => Edit UI를 페이드아웃 -> 제거 -> 메인 UI 페이드인
-   * - 메인 UI가 보이는 상태라면 => /pos 로 페이지 이동
-   */
   const handleBackClick = () => {
     if (showEditUI) {
-      // 1) Edit UI 페이드아웃 시작
       setFadeOutEditUI(true);
-
-      // 2) 0.4s 후 Edit UI 제거 + 메인 UI 표시
       setTimeout(() => {
         setShowEditUI(false);
         setFadeOutEditUI(false);
         setShowMainUI(true);
       }, 400);
     } else {
-      // 메인 UI가 보이는 상태 => POS로 이동
       router.push("/pos");
     }
   };
@@ -148,7 +116,6 @@ export default function SettingPage() {
   return (
     <div className="flex items-center font-mono justify-center h-screen w-screen relative">
       <div className="relative w-4/5 h-4/5 bg-white bg-opacity-20 border border-gray-400 rounded-2xl p-6 flex flex-col justify-center items-center">
-        {/* 왼쪽 상단으로 돌아가기(또는 메인으로 복귀) 버튼 */}
         <button
           onClick={handleBackClick}
           className="absolute top-0 left-0 bg-transparent px-2 py-2 text-gray-500 text-sm rounded hover:text-gray-400"
@@ -156,19 +123,15 @@ export default function SettingPage() {
           <ChevronLeft className="w-8 h-8" />
         </button>
 
-        {/* 메인 UI (Heading + 6개 버튼) */}
         {showMainUI && (
           <div
             className={`flex flex-col items-center justify-start ${
               fadeOutMainUI ? "fade-out fade-out-active" : ""
             }`}
           >
-            {/* Heading */}
             <h1 className="text-[40px] font-sans font-bold text-gray-700 mb-[120px]">
               Customize POS Settings
             </h1>
-
-            {/* 6개 버튼 */}
             <div className="grid grid-cols-2 gap-8 w-full relative">
               <button
                 onClick={handleOrdersClick}
@@ -177,21 +140,13 @@ export default function SettingPage() {
                 <ShoppingBag className="w-6 h-6 mr-2 ml-10" />
                 Orders
               </button>
-              {/* <button
-                className="w-80 h-20 font-bold text-left flex flex-row items-center bg-transparent text-gray-700 border border-gray-500 hover:text-white hover:bg-[#333] rounded-lg shadow-sm"
-              >
-                <SquareChartGantt className="w-6 h-6 mr-2 ml-10" />
-                Management
-              </button> */}
               <button
-                className="w-80 h-20 font-bold text-left flex flex-row items-center bg-transparent text-gray-700 border border-gray-500 hover:text-white hover:bg-[#333] rounded-lg shadow-sm"
                 onClick={handleTransferClick}
+                className="w-80 h-20 font-bold text-left flex flex-row items-center bg-transparent text-gray-700 border border-gray-500 hover:text-white hover:bg-[#333] rounded-lg shadow-sm"
               >
                 <ArrowRightLeft className="w-6 h-6 mr-2 ml-10" />
                 Transfer
               </button>
-
-              {/* Items 버튼 */}
               <button
                 onClick={handleItemsClick}
                 className="w-80 h-20 font-bold text-left flex flex-row items-center bg-transparent text-gray-700 border border-gray-500 hover:text-white hover:bg-[#333] rounded-lg shadow-sm"
@@ -199,13 +154,6 @@ export default function SettingPage() {
                 <Archive className="w-6 h-6 mr-2 ml-10" />
                 Items
               </button>
-
-              {/* <button
-                className="w-80 h-20 font-bold text-left flex flex-row items-center bg-transparent text-gray-700 border border-gray-500 hover:text-white hover:bg-[#333] rounded-lg shadow-sm"
-              >
-                <Settings className="w-6 h-6 mr-2 ml-10" />
-                Settings
-              </button> */}
               <button
                 onClick={handleCloseClick}
                 className="w-80 h-20 font-bold text-left flex flex-row items-center bg-transparent text-gray-700 border border-gray-500 hover:text-white hover:bg-[#333] rounded-lg shadow-sm"
@@ -217,7 +165,6 @@ export default function SettingPage() {
           </div>
         )}
 
-        {/* Edit Items & Edit Categories 버튼 */}
         {showEditUI && (
           <div
             className={`fade-in ${
@@ -247,13 +194,8 @@ export default function SettingPage() {
           </div>
         )}
 
-        {/* Close Business Confirmation Modal */}
-
         {showCloseModal && (
-          <Modal
-            isOpen={showCloseModal}
-            onClose={() => setShowCloseModal(false)}
-          >
+          <Modal isOpen={showCloseModal} onClose={() => setShowCloseModal(false)}>
             <span className="text-md mb-4">영업을 마감하시겠습니까?</span>
             <div className="flex space-x-4">
               <button
@@ -272,7 +214,6 @@ export default function SettingPage() {
           </Modal>
         )}
 
-        {/* Incomplete Order Alert Modal */}
         <AnimatePresence>
           {showIncompleteOrderModal && (
             <motion.div

--- a/components/PlaceModal.tsx
+++ b/components/PlaceModal.tsx
@@ -1,8 +1,9 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import axiosInstance from "@/lib/axiosInstance";
-import { usePosStore, SelectedItem } from "../store/usePosStore"; // SelectedItem 임포트
+import { usePosStore, SelectedItem, Menu } from "../store/usePosStore"; // SelectedItem 임포트
 import { motion, AnimatePresence } from "framer-motion";
+import Cookies from "js-cookie";
 
 interface Place {
   placeId?: number;
@@ -44,11 +45,14 @@ export default function PlaceModal({
   const [newPlaceName, setNewPlaceName] = useState("");
 
   useEffect(() => {
-    const saved = localStorage.getItem("currentStoreId");
-    if (saved) {
-      setStoreId(Number(saved));
-    }
-  }, []);
+    const interval = setInterval(() => {
+      const saved = Cookies.get("currentStoreId");
+      if (saved && Number(saved) !== storeId) {
+        setStoreId(Number(saved));
+      }
+    }, 100); // 1초마다 확인
+    return () => clearInterval(interval);
+  }, [storeId]);
 
   useEffect(() => {
     if (storeId) {
@@ -160,7 +164,7 @@ export default function PlaceModal({
           let realMenuId = menu.id ?? menu.menuId ?? null;
           if (!realMenuId && menu.menuName) {
             // menuCache에 있는 해당 이름의 메뉴를 검색
-            const allMenus = Object.values(menuCache).flat();
+            const allMenus = Object.values(menuCache).flatMap((menus) => Object.values(menus).flat());
             const found = allMenus.find((m) => m.menuName === menu.menuName);
             if (found) {
               realMenuId = found.menuId;

--- a/lib/axiosInstance.ts
+++ b/lib/axiosInstance.ts
@@ -1,19 +1,21 @@
 import axios from "axios";
+import Cookies from "js-cookie";
 
-const API_BASE_URL = "http://52.79.57.150:8383"; // 백엔드 서버 주소
+const API_BASE_URL = "http://localhost:8383"; // 백엔드 서버 주소
 
 const axiosInstance = axios.create({
-  baseURL: "api",
+  baseURL: API_BASE_URL,
   headers: {
     "Content-Type": "application/json",
   },
+  withCredentials: true, // 쿠키를 서버와 함께 주고받기 위해 추가
 });
 
 axiosInstance.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem("accessToken");
-    if (token) {
-      config.headers["Authorization"] = `Bearer ${token}`;
+    const accessToken = Cookies.get("accessToken");
+    if (accessToken) {
+      config.headers["Authorization"] = `Bearer ${accessToken}`;
     }
     return config;
   },
@@ -24,46 +26,48 @@ axiosInstance.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config;
-    
-    // 401 에러 & 재시도하지 않은 경우만 처리
+
     if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true;
-      
-      // 리프레시 토큰이 없으면 로그인 페이지로 리디렉션
-      const refreshToken = localStorage.getItem("refreshToken");
+      const refreshToken = Cookies.get("refreshToken");
+
       if (!refreshToken) {
         alert("세션이 만료되었습니다. 다시 로그인해주세요.");
-        localStorage.clear();
+        Cookies.remove("accessToken");
+        Cookies.remove("refreshToken");
         window.location.href = "/";
         return Promise.reject(error);
       }
-      
+
       try {
-        // 전체 URL을 사용하여 리프레시 토큰 요청
-        const refreshResponse = await axios.post(`/api/auth/refresh`, { 
-          refreshToken 
-        });
-        
-        if (refreshResponse.data?.accessToken) {
-          localStorage.setItem("accessToken", refreshResponse.data.accessToken);
-          if (refreshResponse.data.refreshToken) {
-            localStorage.setItem("refreshToken", refreshResponse.data.refreshToken);
+        const refreshResponse = await axiosInstance.post("/auth/refresh", { refreshToken });
+        if (refreshResponse.data.access_token) {
+          Cookies.set("accessToken", refreshResponse.data.access_token, {
+            expires: 1 / 24, // 1시간 유효
+            secure: true, // HTTPS에서만 전송
+            sameSite: "Strict", // CSRF 방지
+          });
+          if (refreshResponse.data.refresh_token) {
+            Cookies.set("refreshToken", refreshResponse.data.refresh_token, {
+              expires: 7, // 7일 유효
+              secure: true,
+              sameSite: "Strict",
+            });
           }
-          
-          // 인증 헤더 업데이트
-          axios.defaults.headers.common["Authorization"] = `Bearer ${refreshResponse.data.accessToken}`;
-          originalRequest.headers["Authorization"] = `Bearer ${refreshResponse.data.accessToken}`;
-          
-          return axios(originalRequest);
+          axiosInstance.defaults.headers.common["Authorization"] = `Bearer ${refreshResponse.data.access_token}`;
+          originalRequest.headers["Authorization"] = `Bearer ${refreshResponse.data.access_token}`;
+          return axiosInstance(originalRequest);
+        } else {
+          throw new Error("No access_token in refresh response");
         }
       } catch (refreshError) {
-        console.error("토큰 갱신 실패:", refreshError);
         alert("인증이 만료되었습니다. 다시 로그인해주세요.");
-        localStorage.clear();
+        Cookies.remove("accessToken");
+        Cookies.remove("refreshToken");
         window.location.href = "/";
+        return Promise.reject(refreshError);
       }
     }
-    
     return Promise.reject(error);
   }
 );

--- a/lib/axiosInstance.ts
+++ b/lib/axiosInstance.ts
@@ -1,9 +1,9 @@
 import axios from "axios";
 
-const API_BASE_URL = "http://localhost:8383"; // 백엔드 서버 주소
+const API_BASE_URL = "http://52.79.57.150:8383"; // 백엔드 서버 주소
 
 const axiosInstance = axios.create({
-  baseURL: "/api",
+  baseURL: "api",
   headers: {
     "Content-Type": "application/json",
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "date-fns": "^4.1.0",
         "framer-motion": "^12.3.1",
         "gsap": "^3.12.7",
+        "js-cookie": "^3.0.5",
         "lodash": "^4.17.21",
         "lucide-react": "^0.475.0",
         "next": "14.2.0",
@@ -27,6 +28,7 @@
         "zustand": "^5.0.3"
       },
       "devDependencies": {
+        "@types/js-cookie": "^3.0.6",
         "@types/lodash": "^4.17.16",
         "@types/node": "^20",
         "@types/react": "^18",
@@ -410,6 +412,12 @@
       "peerDependencies": {
         "react": "^18 || ^19"
       }
+    },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
+      "dev": true
     },
     "node_modules/@types/lodash": {
       "version": "4.17.16",
@@ -1303,6 +1311,14 @@
       "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "date-fns": "^4.1.0",
     "framer-motion": "^12.3.1",
     "gsap": "^3.12.7",
+    "js-cookie": "^3.0.5",
     "lodash": "^4.17.21",
     "lucide-react": "^0.475.0",
     "next": "14.2.0",
@@ -28,6 +29,7 @@
     "zustand": "^5.0.3"
   },
   "devDependencies": {
+    "@types/js-cookie": "^3.0.6",
     "@types/lodash": "^4.17.16",
     "@types/node": "^20",
     "@types/react": "^18",

--- a/store/formStore.ts
+++ b/store/formStore.ts
@@ -1,4 +1,3 @@
-// stores/formStore.ts
 import { create } from "zustand";
 
 interface FormState {
@@ -17,9 +16,9 @@ interface FormState {
   selectedDate: string | null;
   dailyOrders: { [date: string]: FullOrder[] };
   isCalculatorModalOpen: boolean;
-  setStoreId: (id: number) => void;
-  setPlaceId: (id: number) => void;
-  setSelectedOrder: (orderId: number, date: string) => void;
+  setStoreId: (id: number | null) => void;
+  setPlaceId: (id: number | null) => void;
+  setSelectedOrder: (orderId: number | null, date: string | null) => void;
   setDailyOrders: (date: string, orders: FullOrder[]) => void;
   setCalculatorModalOpen: (open: boolean) => void;
 }
@@ -58,5 +57,4 @@ export const useFormStore = create<FormState>((set) => ({
     dailyOrders: { ...state.dailyOrders, [date]: orders },
   })),
   setCalculatorModalOpen: (open) => set({ isCalculatorModalOpen: open }),
-
 }));

--- a/types/order.ts
+++ b/types/order.ts
@@ -1,6 +1,7 @@
 export interface OrderSummary {
   totalPrice: number;
   date: string;
+  status: string;
 }
 
 export interface Order {


### PR DESCRIPTION
클라이언트 측에서 인증 토큰을 관리하는 방식을 로컬스토리지에서 쿠키로 전환했다. 
`useEffect`에서 `window.localStorage.getItem("authToken")`으로 토큰을 가져오던 로직을 삭제하고, 
HTTP-Only 쿠키로 토큰을 설정해 보안성을 높였다. axiosInstance에 토큰을 수동으로 설정할 필요가 없어졌으니 코드가 간결해졌다. 

그리고 캐싱 처리도 개선했다. `@tanstack/react-query`에서 `cacheTime`이 `gcTime`으로 바뀐 걸 반영해 타입 오류를 수정했고, `staleTime`과 `gcTime`을 0으로 설정해 항상 최신 데이터를 가져오게 했다. 

`refetchOnMount: "always"`도 추가해서 컴포넌트 마운트 시 데이터가 강제로 갱신되도록 했다. 
환불 후 `orderSummaries`가 즉시 반영되도록 `invalidateQueries`와 `refetchQueries`를 조합해 캐시 무효화와 데이터 재요청을 보장했다. 월매출 조회에서 결제 취소가 바로 반영되니 사용자 경험이 훨씬 나아졌다.

처음부터 HTTP-Only 쿠키로 토큰을 관리하고, gcTime과 staleTime을 0으로 설정해 캐싱을 최소화했으면 데이터 갱신 문제를 피했을 거다. refetchQueries도 일찍 썼으면 더 빨리 해결됐을듯. 그래도 이렇게 알아 가니 다음 프로젝트에서는 잘 적용해 볼 수 있겠다!